### PR TITLE
docs(form-rating): add documentation, data file & live demos

### DIFF
--- a/apps/docs/src/components/TableOfContentsNav.vue
+++ b/apps/docs/src/components/TableOfContentsNav.vue
@@ -118,6 +118,7 @@ const componentsList: {name: string}[] = [
   {name: 'Form Group'},
   {name: 'Form Input'},
   {name: 'Form Radio'},
+  {name: 'Form Rating'},
   {name: 'Form Select'},
   {name: 'Form Tags'},
   {name: 'Form Spinbutton'},

--- a/apps/docs/src/data/components/FormRating.data.ts
+++ b/apps/docs/src/data/components/FormRating.data.ts
@@ -1,0 +1,108 @@
+import type {BvnComponentProps} from 'bootstrap-vue-next'
+import {type ComponentReference, type PropertyReference} from '../../types'
+import {buildCommonProps, pick} from '../../utils'
+
+export default {
+  load: (): ComponentReference[] => [
+    {
+      component: 'BFormRating',
+      sourcePath: '/BFormRadio/BFormRadio.vue',
+      props: {
+        '': {
+          color: {
+            type: 'string',
+            default: undefined,
+            description:
+              'CSS color to use instead of variant. Accepts either a HEX or RGB/RGBA string',
+          },
+          modelValue: {
+            type: 'number',
+            default: undefined,
+            description: 'The current rating value (supports v-model two-way binding).',
+          },
+          precision: {
+            type: 'Number or String',
+            default: undefined,
+            description:
+              'Specify the number of digits after the decimal to show. Defaults to to no defined precision',
+          },
+          readonly: {
+            type: 'Boolean',
+            default: 'false',
+            description:
+              'When `true` makes the rating readonly. When `true`, fractional ratings values are allowed (half icons will be shown)',
+          }, //
+          showValue: {
+            type: 'boolean',
+            default: 'false',
+            description: 'When `true` shows the current rating value in the control',
+          },
+          showValueMax: {
+            type: 'boolean',
+            default: 'false',
+            description:
+              'When set to `true` and prop `show-value` is `true`, includes the maximum star rating possible in the formatted value',
+          },
+          stars: {
+            type: 'Number or String',
+            default: '5',
+            description: 'The number of stars to show. Minimum value is `3`, default is `5`',
+          },
+          variant: {
+            type: 'String',
+            default: undefined,
+            description: 'Applies one of the Bootstrap theme color variants to the component',
+          },
+          size: {
+            type: 'String',
+            default: 'md',
+            description:
+              "Icon size: accepts CSS units (e.g. '1.5rem', '24px') or the presets 'sm' (small) and 'lg' (large); defaults to medium.",
+          },
+          //modify icons props later on
+          iconFull: {
+            type: 'String',
+            default: '',
+            description: '',
+          },
+          iconHalf: {
+            type: 'String',
+            default: '',
+            description: '',
+          },
+          iconEmpty: {
+            type: 'String',
+            default: '',
+            description: '',
+          },
+          ...pick(buildCommonProps(), ['form', 'id', 'name']),
+        } satisfies Record<keyof BvnComponentProps['BFormRating'], PropertyReference>,
+      },
+      emits: [
+        {
+          event: 'update:model-value',
+          args: [
+            {
+              arg: 'value',
+              description: 'Currently selected value of the select control.',
+              type: 'SelectValue',
+            },
+          ],
+          description:
+            'Emitted when the selected value(s) are changed. Looking for the `input` or `change` event - use `update:model-value` instead.',
+        },
+      ],
+      slots: [
+        {
+          description: 'Content to place in the form select',
+          name: 'default',
+        },
+        {
+          description:
+            "Slot to place options or option groups above options provided via the 'options' prop",
+          name: 'first',
+        },
+      ],
+    },
+  ],
+}

--- a/apps/docs/src/docs/components/demo/RatingCustomColor.vue
+++ b/apps/docs/src/docs/components/demo/RatingCustomColor.vue
@@ -1,0 +1,13 @@
+<template>
+  <BFormRating v-model="rating" color="indigo" />
+  <BFormRating v-model="rating" color="#ff00ff" />
+  <BFormRating v-model="rating" color="rgb(64, 192, 128)" />
+  <BFormRating v-model="rating" color="rgba(64, 192, 128, 0.75" />
+
+  <p>Current rating: {{ rating }}</p>
+</template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+const rating = ref(3)
+</script>

--- a/apps/docs/src/docs/components/demo/RatingInteractive.vue
+++ b/apps/docs/src/docs/components/demo/RatingInteractive.vue
@@ -1,0 +1,10 @@
+<template>
+  <BFormRating v-model="rating" />
+
+  <p>Current rating: {{ rating }}</p>
+</template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+const rating = ref(0)
+</script>

--- a/apps/docs/src/docs/components/demo/RatingNonInteractive.vue
+++ b/apps/docs/src/docs/components/demo/RatingNonInteractive.vue
@@ -1,0 +1,10 @@
+<template>
+  <BFormRating v-model="rating" :readonly="true" />
+
+  <p>Current rating: {{ rating }}</p>
+</template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+const rating = ref(2.567)
+</script>

--- a/apps/docs/src/docs/components/demo/RatingPrecision.vue
+++ b/apps/docs/src/docs/components/demo/RatingPrecision.vue
@@ -1,0 +1,10 @@
+<template>
+  <BFormRating v-model="rating" show-value :precision="2" />
+
+  <p>Current rating: {{ rating }}</p>
+</template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+const rating = ref(3.555)
+</script>

--- a/apps/docs/src/docs/components/demo/RatingReadOnly.vue
+++ b/apps/docs/src/docs/components/demo/RatingReadOnly.vue
@@ -1,0 +1,9 @@
+<template>
+  <label for="rating-readonly">Readonly rating</label>
+  <BFormRating id="rating-readonly" v-model="rating" readonly show-value :precision="3" />
+</template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+const rating = ref(3.6536)
+</script>

--- a/apps/docs/src/docs/components/demo/RatingSizing.vue
+++ b/apps/docs/src/docs/components/demo/RatingSizing.vue
@@ -1,0 +1,17 @@
+<template>
+  <label for="rating-sm">Small rating</label>
+  <BFormRating v-model="rating" size="sm" />
+
+  <label for="rating-md">Default rating (medium)</label>
+  <BFormRating id="rating-md" v-model="rating" />
+
+  <label for="rating-lg">Large rating</label>
+  <BFormRating v-model="rating" size="lg" />
+
+  <p>Current rating: {{ rating }}</p>
+</template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+const rating = ref(4)
+</script>

--- a/apps/docs/src/docs/components/demo/RatingStars.vue
+++ b/apps/docs/src/docs/components/demo/RatingStars.vue
@@ -1,0 +1,15 @@
+<template>
+  <label>Rating with 10 stars:</label>
+  <BFormRating v-model="rating10" :stars="10" />
+  <p>Value: {{ rating10 }}</p>
+
+  <label>Rating with 7 stars:</label>
+  <BFormRating v-model="rating7" :stars="7" />
+  <p class="mt-2">Value: {{ rating7 }}</p>
+</template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+const rating10 = ref(0)
+const rating7 = ref(0)
+</script>

--- a/apps/docs/src/docs/components/demo/RatingValue.vue
+++ b/apps/docs/src/docs/components/demo/RatingValue.vue
@@ -1,0 +1,10 @@
+<template>
+  <BFormRating v-model="rating" show-value />
+
+  <p>Current rating: {{ rating }}</p>
+</template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+const rating = ref(4)
+</script>

--- a/apps/docs/src/docs/components/demo/RatingValueMax.vue
+++ b/apps/docs/src/docs/components/demo/RatingValueMax.vue
@@ -1,0 +1,9 @@
+<template>
+  <BFormRating v-model="rating" show-value-max :precision="2" />
+  <p>Current rating: {{ rating }}</p>
+</template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+const rating = ref(3.555)
+</script>

--- a/apps/docs/src/docs/components/demo/RatingVariant.vue
+++ b/apps/docs/src/docs/components/demo/RatingVariant.vue
@@ -1,0 +1,14 @@
+<template>
+  <BFormRating v-model="rating" variant="warning" />
+  <BFormRating v-model="rating" variant="success" />
+  <BFormRating v-model="rating" variant="danger" />
+  <BFormRating v-model="rating" variant="primary" />
+  <BFormRating v-model="rating" variant="info" />
+
+  <p>Current rating: {{ rating }}</p>
+</template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+const rating = ref(3)
+</script>

--- a/apps/docs/src/docs/components/form-rating.md
+++ b/apps/docs/src/docs/components/form-rating.md
@@ -1,0 +1,104 @@
+# Form Rating
+
+<PageHeader>
+
+BootstrapVue's custom star rating component, `BFormRating`, is for entering or displaying a rating value. The component is fully WAI-ARIA accessible and supports keyboard control.
+
+</PageHeader>
+
+## Overview
+
+Rating values range from 1 to the number of stars allowed (default stars is `5`, minimum stars is `3`). Since `BFormRating` uses the Bootstrap class `form-control`, it can easily be placed inside [input groups](/docs/components/input-group.html).
+
+There are two main modes for `BFormRating`: interactive and readonly.
+
+Interactive mode allows the user to chose a rating from 1 to the number of stars (default 5) in whole number increments.
+
+**Interactive rating (input mode):**
+
+<<< DEMO ./demo/RatingInteractive.vue
+
+Readonly mode is used for displaying an aggregated rating, and supports `half` stars.
+
+**Readonly (non-interactive) rating:**
+
+<<< DEMO ./demo/RatingNonInteractive.vue
+
+## Styling
+
+### Variant and color
+
+Easily apply one of the Bootstrap theme color variants to the rating icon via the `variant` prop.
+The default is to use the default form control text color.
+
+<<< DEMO ./demo/RatingVariant.vue
+
+To apply a _custom color_, use the `color` prop which accepts a standard CSS color name, HEX color
+value (`#...`) or RGB/RGBA (`rgb(...)`/`rgba(...)`) color value:
+
+<<< DEMO ./demo/RatingCustomColor.vue
+**Notes:**
+
+- The prop `color` takes precedence over the `variant` prop
+- Variants translate to the `text-{variant}` utility class on the icon
+
+### Number of stars
+
+By default, `<BFormRating>` defaults to `5` stars. You can change the number of stars via the
+`stars` prop. The minimum allowed stars is `3`.
+
+<<< DEMO ./demo/RatingStars.vue
+
+### Show value
+
+By default `<BFormRating>` does not display the current numerical value. To show the current value
+simply set the `show-value` prop to `true`. To control the precision (number of digits after the
+decimal) simply set the `precision` prop to the number of digits after the decimal to show. The
+`precision` setting is useful when showing an aggregated or average rating value in `readonly` mode.
+
+<<< DEMO ./demo/RatingValue.vue
+
+**With precision set:**
+
+<<< DEMO ./demo/RatingPrecision.vue
+
+#### Show maximum value
+
+Optionally show the maximum rating possible by also setting the prop `show-value-max` to `true`:
+
+<<< DEMO ./demo/RatingValueMax.vue
+
+### Control sizing
+
+Fancy a small or large rating control? Simply set the prop `size` to either `'sm'` or `'lg'`
+respectively.
+
+<<< DEMO ./demo/RatingSizing.vue
+
+### Inline mode
+
+By default, `<BFormRating>` occupies 100% width of the parent container. In some situations you
+may prefer the custom input to occupy on the space required for it's contents. Simply set the
+`inline` prop to `true` to render the component in inline mode:
+
+<!--RatingInline.vue-->
+
+### Readonly
+
+Readonly ratings remain focusable, but are not interactive. This state is useful for displaying an
+aggregated or average ratings value. Fractional values are allowed and will result in the displaying
+of _half icons_ when the `value` is not a whole number (the half icon threshold is `0.5`).
+
+<<< DEMO ./demo/RatingReadOnly.vue
+
+<ComponentReference :data="data" />
+
+<script lang="ts">
+import {data} from '../../data/components/FormRating.data'
+
+export default {
+setup() {
+return {data}
+}
+}
+</script>


### PR DESCRIPTION
# Create the initial Documentation for <BFormRating>

This pull request adds the first-pass documentation for the new BFormRating component in BootstrapVueNext:
	•	FormRating.data.ts: Prop metadata (types, defaults, descriptions) aligned with BFormRatingProps
	•	form-rating.md: Overview, usage examples, live demos for all features (show-value, show-value-max, precision, star count, variants, custom color, sizes, readonly)
	•	Demo components under docs/components/demo/ illustrating each feature in isolation
	•	Updated sidebar/index page to link to the new “Form Rating” docs section

# Documentation Check List
- [x] Interactive Rating 
- [x] Non interactive 
- [x] Variant and color 
- [x] Number of stars 
- [x] Show value 
	- [x] With precision 
- [x] Show value 
- [x] Show maximum value 
- [x] Control sizing 
- [x] Read Only 
- [ ] Inline mode
- [ ] Borderless
- [ ] Disabled
- [ ] Clear Button
- [ ] Custom Icon
- [ ] Form submission
- [ ] Using in input groups
- [ ] internationalization
- [ ] Accessibility
- [ ] FormRating.data.ts (component Reference)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced documentation and demos for the new star rating component, allowing interactive and readonly rating inputs with customizable appearance, precision, and star count.
- **Documentation**
  - Added comprehensive documentation for the star rating component, detailing usage, accessibility, customization options, and examples.
- **Chores**
  - Updated navigation to include the new star rating component in the Table of Contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->